### PR TITLE
New PR after Action is set to required

### DIFF
--- a/dummy-files/dummy2.txt
+++ b/dummy-files/dummy2.txt
@@ -1,0 +1,1 @@
+Dummy test for `new_pr`.


### PR DESCRIPTION
_Check if recent push is only a rebase on the base branch_ is set to only execute on `synchronize`, not on `opened` (https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request) resulting in blocked state for newly opened PR if set to required:
![image](https://user-images.githubusercontent.com/4901762/177167044-987da9e3-2aea-4f53-a1d3-a2bacd1c3716.png)
