### PR TITLE
Move `action == synchronize` condition from step to job level

### DIFF
--- a/.github/workflows/pr-push-rebase-check.yml
+++ b/.github/workflows/pr-push-rebase-check.yml
@@ -8,14 +8,14 @@ on:
 
 jobs:
   pull-request:
-    name: Check if recent push is only a rebase on the base branch
+    # Run this job only for pull_request:synchronize (push to head branch).
+    if: github.event.action == 'synchronize'
+    name: 'Check if recent push is only a rebase on the base branch'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check patch files
+      - name: 'Check patch files'
         id: check-if-pure-rebase
-        # Execute this step only on push/synchronize (event_name is always 'pull_request')
-        if: github.event.action == 'synchronize'
         uses: actions/github-script@v6
         with:
           result-encoding: string
@@ -118,8 +118,3 @@ jobs:
       - name: Add summary
         if: steps.check-if-pure-rebase.outcome == 'success'
         run: echo "${{steps.check-if-pure-rebase.outputs.result}}" >> $GITHUB_STEP_SUMMARY
-
-      - name: Skip this check (not a push)
-        # Execute this step only if check-if-pure-rebase was not executed (trigger was not a push)
-        if: steps.check-if-pure-rebase.outcome == 'skipped'
-        run: echo "This check was skipped ('${{ github.event_name }}' action was '${{ github.event.action }}')" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
This keeps the workflow behavior unchanged for `synchronize` events but optimizes/simplifies handling of opened/reopened pull requests by skipping the whole job instead of running a no-op step just to finish successfully.

This does not break Required Status Check behavior: GitHub Actions treats jobs skipped by a conditional (`jobs.<job_id>.if`) as successful, so the required check still passes on PR open/reopen even though no steps are executed.

Source:
> If, however, a job within a workflow is skipped due to a conditional, it will report its status as "Success". For more information, see [Using conditions to control job execution](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-conditions-to-control-job-execution).

https://docs.github.com/en/enterprise-cloud@latest/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks